### PR TITLE
Add automated testing and deployment with Travis; add linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - gem install mdl
 before_script:
 # syntax, linting and pre-test stages
-  - mdl README.md
+  - mdl -s relaxed README.md
   - shellcheck src/check_oneprovider
   - shellcheck src/check_onezone
   - docker build -t onedata-nagios-test -f Dockerfile.nginx .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+---
+sudo: required
+services:
+  - docker
+language: ruby
+rvm:
+  - 2.0.0
+addons:
+  apt:
+    packages:
+      - shellcheck
+before_install:
+install:
+  - gem install mdl
+before_script:
+# syntax, linting and pre-test stages
+  - mdl README.md
+  - shellcheck src/check_oneprovider
+  - shellcheck src/check_onezone
+  - docker build -t onedata-nagios-test -f Dockerfile.nginx .
+script:
+# Actual testing of the product
+# First, start the build container
+  - docker run --name build_container -d -ti -v $PWD:/tmp -w /tmp centos:6 /bin/bash -c 'while true sleep 1000'
+# Now, install prerequisites for the build
+  - docker exec -i -w /root build_container yum install -y rpm-build
+# and ensure the build paths are present
+  - docker exec -i -w /root bash -c 'mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}'
+# make the tarball  
+  - docker exec -i build_container -w /tmp/ make
+# and copy it to the place rpmbuild expects it
+  - docker exec -i -w /tmp build_container cp nagios-plugins-onedata*tar.gz /root/rpmbuild/SOURCES
+# now build the rpm
+  - docker exec -i -w /tmp build_container rpmbuild -bb nagios-plugins-onedata.spec
+# and install it
+  - docker exec -i -w /tmp build_container rpmbuild rpm -Uvh nagios-plugins-onedata-3.0.0-1.el6.noarch.rpm
+# now see if it runs
+  - docker exec -ti build_container bash /usr/lib64/argo-monitoring/probes/org.onedata/check_onezone -h
+# if it works, get the rpm we just built to the shared volume
+  - docker exec build_container cp /root/rpmbuild/RPMS/noarch/*.rpm /tmp
+  - tests/test.sh
+before_cache:
+after_success:
+after_failure:
+before_deploy:
+deploy:
+  provider: releases
+  api_key:
+  file:
+    - nagios-plugins-onedata-3.2.0-1.el6.noarch.rpm
+  on:
+    tags: true
+after_deploy:
+after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: ruby
 rvm:
-  - 2.0.0
+  - 2.4.1
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-
 # nagios-plugins-onedata
 
-This repository contains Nagios plugins for testing Onedata services availability, namely `Oneprovider` and `Onezone` services.
+This repository contains Nagios plugins for testing Onedata services availability,
+namely `Oneprovider` and `Onezone` services.
 
 ## Requirements
+
 These Nagios probes have the following requirements in order to work properly:
+
 - Bash
 - cURL
 - xmllint (from libxml2-utils)
@@ -13,7 +15,9 @@ These Nagios probes have the following requirements in order to work properly:
 ## Running the probes
 
 ### Oneprovider
+
 Oneprovider probe supports the following command line options:
+
 ```bash
 Nagios plugin for Oneprovider service of Onedata
 
@@ -29,6 +33,7 @@ src/check_oneprovider [-h|--help] [-t|--timeout <timeout>] [-p|--port <port>]
 ```
 
 ### Onezone
+
 ```bash
 Nagios plugin for Onezone service of Onedata
 
@@ -42,12 +47,17 @@ src/check_oneprovider [-h|--help] [-t|--timeout <timeout>] [-p|--port <port>]
  -p|--port    - The Onedata Nagios port (Default: 6666)
  -u|--url     - The complete Onedata Nagios endpoint
 ```
+
 ### How the probes work
-Each of Onedata services (Onezone, Oneprovider) expose an endpoint with health data in XML for all worker processes running on a given site (each Onedata service can have mutliple worker processes running in parallel for higher performance and reliability).
+
+Each of Onedata services (Onezone, Oneprovider) expose an endpoint with health data in
+XML for all worker processes running on a given site (each Onedata service can have
+mutliple worker processes running in parallel for higher performance and reliability).
 
 By default all Onedata service provide this information on port `6666` so it must be ensured that this port is opened on the Onedata sites to the nodes where Nagios monitoring probes are executed.
 
 An example XML output for a Onezone service is below:
+
 ```xml
 <?xml version="1.0"?>
 <healthdata date="2016/11/24 13:10:02" status="error">
@@ -86,55 +96,55 @@ An example XML output for a Onezone service is below:
 </healthdata>
 ```
 
-In case all workers are working and the healthdata status is `ok` the probe will return `OK` status.
+In case all workers are working and the health data status is ok, the probe will return `OK` status.
 
 If all of the workers are down and return `error` status the probe will return a `CRITICAL` status code and in case at least one worker is still running the status will be `WARNING`.
-
 
 ## Building CentOS RPM
 
 Building can be done on a Centos 6 Docker container:
+
 ```bash
 #
-# Build the RPM from scratch 
+# Build the RPM from scratch
 #
-$ docker run -ti centos:6 /bin/bash
-$ yum install git rpm-build
-$ cd /root
-$ mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-$ git clone https://github.com/onedata/nagios-plugins-onedata
-$ cd nagios-plugins-onedata
-$ make
-$ cp nagios-plugins-onedata*tar.gz ../rpmbuild/SOURCES
-$ rpmbuild -bb nagios-plugins-onedata.spec
+docker run -ti centos:6 /bin/bash
+yum install git rpm-build
+cd /root
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+git clone https://github.com/onedata/nagios-plugins-onedata
+cd nagios-plugins-onedata
+make
+cp nagios-plugins-onedata*tar.gz ../rpmbuild/SOURCES
+rpmbuild -bb nagios-plugins-onedata.spec
 
 #
 # Install and test the RPM
 #
-$ cd ../rpmbuild/RPMS/noarch
-$ rpm -Uvh nagios-plugins-onedata-3.0.0-1.el6.noarch.rpm
-$ /usr/lib64/argo-monitoring/probes/org.onedata/check_onezone -h
+cd ../rpmbuild/RPMS/noarch
+rpm -Uvh nagios-plugins-onedata-3.0.0-1.el6.noarch.rpm
+/usr/lib64/argo-monitoring/probes/org.onedata/check_onezone -h
 ```
 
 ## Running probe unit tests
 
-First create and start the Docker, which serves the mockup healthdata XML files:
+First create and start the Docker, which serves the mockup health data XML files:
 
 ```bash
-$ cd nagios-plugins-onedata
-$ docker build --file docker/Dockerfile.nginx -t onedata-nagios-test .
-$ docker run -t -d -p 80:80 onedata-nagios-test
+cd nagios-plugins-onedata
+docker build --file docker/Dockerfile.nginx -t onedata-nagios-test .
+docker run -t -d -p 80:80 onedata-nagios-test
 ```
 
 Then run the `tests/test.sh` script:
+
 ```bash
-$ tests/test.sh
+tests/test.sh
 ```
 
 Finally stop the Nginx container and optionally destroy it:
+
 ```bash
-$ docker stop $(docker ps -f ancestor=onedata-nagios-test -q)
-$ docker rmi onedata-nagios-test
+docker stop $(docker ps -f ancestor=onedata-nagios-test -q)
+docker rmi onedata-nagios-test
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Building can be done on a Centos 6 Docker container:
 # Build the RPM from scratch
 #
 docker run -ti centos:6 /bin/bash
-yum install git rpm-build
+yum install -y git rpm-build
 cd /root
 mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 git clone https://github.com/onedata/nagios-plugins-onedata


### PR DESCRIPTION
I have added a proposed Travis configuration to actually test the creation and usage of the RPM. It could be extended in a few ways, if necessary, including having it built on a clean CEntOS 7 host, or a clone of an existing ARGO machine to check whether there are conflicts with the other probes (ie, actually do continuous integration)

I've added two steps for linting the markdown running static checks on the shell scripts.

There is also a deploy stage, which should resolve #3 